### PR TITLE
adding a new method 'replaceWith'

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -75,3 +75,16 @@ jBone.fn.remove = function() {
 
     return this;
 };
+
+jBone.fn.replaceWith = function(сontent) {
+    var replacement = сontent instanceof jBone ? сontent[0] : сontent;
+
+    this.forEach(function(el) {
+        if ( el.parentNode ) {
+            el.parentNode.replaceChild(replacement, el);
+            jBone(el).remove();
+        }
+    });
+
+    return this;
+};

--- a/test/manipulation.js
+++ b/test/manipulation.js
@@ -6,6 +6,7 @@ describe('jBone Manipulation', function() {
         expect(jBone().appendTo).to.be.a("function");
         expect(jBone().empty).to.be.a("function");
         expect(jBone().remove).to.be.a("function");
+        expect(jBone().replaceWith).to.be.a("function");
     });
 
     it('html(jBone)', function() {
@@ -123,4 +124,21 @@ describe('jBone Manipulation', function() {
 
         expect(a).to.be.a(jBone);
     });
+
+    it('replaceWith(HTMLElement)', function() {
+        var parent      = jBone('<div><a>');
+        var replacement = document.createElement("b");
+        parent.find('a').replaceWith(replacement);
+        expect(parent[0].childNodes).to.have.length(1);
+        expect(parent[0].childNodes[0]).to.be(replacement);
+    });
+
+    it('replaceWith(jBone)', function() {
+        var parent      = jBone('<div><a>');
+        var replacement = jBone("<b>");
+        parent.find('a').replaceWith(replacement);
+        expect(parent[0].childNodes).to.have.length(1);
+        expect(parent[0].childNodes[0]).to.be(replacement[0]);
+    });
+
 });


### PR DESCRIPTION
Did by analogy jquery

The `.replaceWith()` method removes content from the DOM and inserts new content in its place with a single call. Consider this DOM structure:

``` html
<nav>
  <a class="first" href="#first">first</a>
  <a class="second" href="#second">second</a>
</nav>
```

The second element could be replaced with new element

``` javascript
newEl = jBone('<b>second<b>')
jBone('.second').replaceWith(newEl)
```

This results in the structure:

``` html
<nav>
  <a class="first" href="#first">first</a>
  <b>second<b>
</nav>
```

`replaceWith` works with jBone and with DOM elements
