### PR TITLE
Fix: jBone's `trigger('click')` didn't work in Firefox and stopped working in new Chrome

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -204,8 +204,8 @@ jBone.event = {
                 return;
             }
 
-            if (event.type == 'click') {
-                el.click();
+            if (event.type === "click") {
+                el.click && el.click();
             } else {
                 el.dispatchEvent && el.dispatchEvent(event);
             }

--- a/src/event.js
+++ b/src/event.js
@@ -204,7 +204,11 @@ jBone.event = {
                 return;
             }
 
-            el.dispatchEvent && el.dispatchEvent(event);
+            if (event.type == 'click') {
+                el.click();
+            } else {
+                el.dispatchEvent && el.dispatchEvent(event);
+            }
         });
     },
 

--- a/src/event.js
+++ b/src/event.js
@@ -204,8 +204,8 @@ jBone.event = {
                 return;
             }
 
-            if (event.type === "click") {
-                el.click && el.click();
+            if (event.type === "click" && el.click) {
+                el.click();
             } else {
                 el.dispatchEvent && el.dispatchEvent(event);
             }


### PR DESCRIPTION
Fix: jBone's `trigger('click')` didn't work in Firefox and stopped working in new Chrome after last update: https://www.chromestatus.com/features/5718803933560832