### PR TITLE
Handle undefined parameter for jBone.val()

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -47,7 +47,7 @@ fn.val = function(value) {
     }
 
     for (; i < length; i++) {
-        this[i].value = value;
+        this[i].value = value != undefined ? value : '';
     }
 
     return this;

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -47,7 +47,7 @@ fn.val = function(value) {
     }
 
     for (; i < length; i++) {
-        this[i].value = value != undefined ? value : '';
+        this[i].value = (value !== undefined && value !== null) ? value : "";
     }
 
     return this;


### PR DESCRIPTION
This way it's not going to set `"undefined"` to a input when an `undefined`or `null` value is passed. jQuery handles this way - check https://github.com/jquery/jquery/blob/master/src/attributes/val.js#L61
An example is:
```javascript
const a = {b: 'b'}
$('input').val(a.c)
```
currently jBone will set "undefined" as the input's value