### PR TITLE
Add missing documentation for get() (no arguments)

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ $.when(deferred).then(function(response) {
 
 * [.find(selector)](https://github.com/kupriyanenko/jbone/wiki/Traversing#findselector)
 * [.get(index)](https://github.com/kupriyanenko/jbone/wiki/Traversing#getindex)
+* [.get()](https://github.com/kupriyanenko/jbone/wiki/Traversing#get)
 * [.eq(index)](https://github.com/kupriyanenko/jbone/wiki/Traversing#eqindex)
 * [.parent()](https://github.com/kupriyanenko/jbone/wiki/Traversing#parent)
 * [.toArray()](https://github.com/kupriyanenko/jbone/wiki/Traversing#toarray)


### PR DESCRIPTION
Both forms of the `get` method are implemented, i.e.:

- `get() => Array<Element>`
- `get(index: number) => Element`

\- but only the latter is documented.

This PR adds a link to the documentation for the no-argument form (which has been added to the wiki).